### PR TITLE
Disabling comments + Removing About from Post Section

### DIFF
--- a/notes.config.js
+++ b/notes.config.js
@@ -51,7 +51,7 @@ const CONFIG = {
     },
   },
   utterances: {
-    enable: true,
+    enable: false,
     config: {
       repo: "kvaishak/notes",
       "issue-term": "og:title",

--- a/src/libs/notion/filterPublishedPosts.js
+++ b/src/libs/notion/filterPublishedPosts.js
@@ -9,7 +9,7 @@ export default function filterPublishedPosts({ posts, includePages }) {
   const publishedPosts = posts
     .filter((post) =>
       includePages
-        ? post?.type?.[0] === "Post" || post?.type?.[0] === "Page"
+        ? post?.type?.[0] === "Post" || post?.type?.[0] === "Page" || post?.type?.[0] === "About"
         : post?.type?.[0] === "Post"
     )
     .filter((post) => {


### PR DESCRIPTION
With the following change, we can introduce a new Type called `About` which wont appear in the Post section and while still having the same Layout as Post. 